### PR TITLE
Add reference to Idris Rules in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ Build Systems à la Carte(Haskell shake build) :  http://delivery.acm.org/10.114
 
 # Existing idris pm
 
-https://github.com/dcao/elba
-
-https://github.com/idream-build/idream
+- **[Elba](https://github.com/elba/elba)** - A package manager for Idris
+- **[idream](https://github.com/idream-build/idream)** - A simple build system for Idris
+- **[Idris Rules](http://idris.build)** - Idris rules for Bazel
 
 # Contribution welcomed!


### PR DESCRIPTION
Hi,

I've been working on adding to bazel some support for indris. I see you have a list of other build tools for idris and I wonder if you would mind adding "Idris Rules" to the list.

It's great to see other people trying to grow the Idris echosystem!

Thanks
Marc